### PR TITLE
Add auto PID tuner script

### DIFF
--- a/agent_control_pkg/config/simulation_params.yaml
+++ b/agent_control_pkg/config/simulation_params.yaml
@@ -1,66 +1,62 @@
-# Simulation Configuration Parameters
-
-# General Simulation Settings
-simulation:
+simulation_settings:
   dt: 0.05
   total_time: 120.0
   num_drones: 3
-enable_fls: false
-
-# Formation Settings
-formation:
-  side_length: 4.0
-  initial_positions:
-    drone_0: [0.0, 1.15]  # Top vertex
-    drone_1: [-2.0, -2.0] # Bottom-left
-    drone_2: [2.0, -2.0]  # Bottom-right
-
-# Phase Settings
-phases:
-  - center: [5.0, 5.0]
-    start_time: 0.0
-  - center: [-5.0, 0.0]
-    start_time: 30.0
-  - center: [0.0, -5.0]
-    start_time: 60.0
-  - center: [5.0, 0.0]
-    start_time: 90.0
-
-# Wind Settings
-wind:
-  enabled: true
+  ziegler_nichols_tuning:
+    enable: false
+    kp_test_value: 0.1
+    simulation_time: 30.0
+controller_settings:
+  pid:
+    kp: 3.1
+    ki: 0.4
+    kd: 2.2
+    output_min: -10.0
+    output_max: 10.0
+  fls:
+    enable: false
+    params_file: "fuzzy_params.yaml"
+scenario_settings:
+  enable_wind: true
+  formation_side_length: 4.0
+  formation:
+    initial_positions:
+      drone_0: [0.0, 1.15]
+      drone_1: [-2.0, -2.0]
+      drone_2: [2.0, -2.0]
   phases:
-    - phase: 1
-      time_windows:
-        - {start: 5.0, end: 15.0, force: [3.0, 0.0]}
-        - {start: 10.0, end: 20.0, force: [0.0, -1.0]}
-    - phase: 2
-      time_windows:
-        - {start: 35.0, end: 45.0, force: [-2.0, 0.0]}
-        - {start: 40.0, end: 50.0, force: [0.0, 1.5]}
-    - phase: 3
-      time_windows:
-        - {start: 65.0, end: 70.0, force: ["sin", 0.0]} # Special case for sine wave
-        - {start: 70.0, end: 72.0, force: [0.0, 4.0]}
-        - {start: 72.0, end: 75.0, force: [0.0, -2.0]}
-  - phase: 4
-    time_windows:
-      - {start: 95.0, end: 105.0, force: [2.5, -2.5]}
-
-# Controller Settings
-controller:
-  enable_fls: false
-
-# Output Settings
-output:
+    - center: [5.0, 5.0]
+      start_time: 0.0
+    - center: [-5.0, 0.0]
+      start_time: 30.0
+    - center: [0.0, -5.0]
+      start_time: 60.0
+    - center: [5.0, 0.0]
+      start_time: 90.0
+  wind:
+    phases:
+      - phase: 1
+        time_windows:
+          - {start_time: 5.0, end_time: 15.0, force: [3.0, 0.0]}
+          - {start_time: 10.0, end_time: 20.0, force: [0.0, -1.0]}
+      - phase: 2
+        time_windows:
+          - {start_time: 35.0, end_time: 45.0, force: [-2.0, 0.0]}
+          - {start_time: 40.0, end_time: 50.0, force: [0.0, 1.5]}
+      - phase: 3
+        time_windows:
+          - {start_time: 65.0, end_time: 70.0, force: [0.0, 0.0], is_sine_wave: true, sine_frequency_rad_s: 1.0}
+          - {start_time: 70.0, end_time: 72.0, force: [0.0, 4.0]}
+          - {start_time: 72.0, end_time: 75.0, force: [0.0, -2.0]}
+      - phase: 4
+        time_windows:
+          - {start_time: 95.0, end_time: 105.0, force: [2.5, -2.5]}
+output_settings:
   csv_enabled: true
   csv_prefix: "multi_drone_pid_test"
   output_directory: "outputs"
+  metrics_enabled: true
+  metrics_prefix: "metrics_sim"
   console_output:
     enabled: true
-    update_interval: 5.0  # seconds
-
-# Fuzzy Logic Settings
-fuzzy_logic:
-  enabled: true
-  params_file: "fuzzy_params.yaml"
+    update_interval: 5.0

--- a/scripts/auto_pid_tuner.py
+++ b/scripts/auto_pid_tuner.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+import glob
+import yaml
+import re
+import time
+
+CONFIG_PATH = os.path.join('agent_control_pkg', 'config', 'simulation_params.yaml')
+BUILD_BIN = os.path.join('agent_control_pkg', 'build', 'multi_drone_pid_tester')
+OUTPUT_DIR = os.path.join('agent_control_pkg', 'build', 'outputs')
+
+# Regex to extract overshoot and settling time from metrics file
+METRIC_RE = re.compile(r"OS=(?P<os>[0-9\.]+)%.*, ST\(2%\)=(?P<st>[0-9\.]+)s")
+
+
+def load_config():
+    with open(CONFIG_PATH, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def save_config(cfg):
+    with open(CONFIG_PATH, 'w') as f:
+        yaml.dump(cfg, f)
+
+
+def run_sim():
+    cwd = os.path.dirname(BUILD_BIN)
+    exe = os.path.basename(BUILD_BIN)
+    subprocess.run([f"./{exe}"], check=True, cwd=cwd)
+
+
+def find_latest_metrics(kp):
+    pattern = os.path.join(OUTPUT_DIR, f"metrics_sim_Kp{kp:.3f}_Ki0.000_Kd0.000_*txt")
+    files = glob.glob(pattern)
+    if not files:
+        return None
+    latest = max(files, key=os.path.getmtime)
+    return latest
+
+
+def parse_metrics(path):
+    if not path or not os.path.exists(path):
+        return None, None
+    with open(path, 'r') as f:
+        for line in f:
+            if line.strip().startswith('X-axis:'):
+                m = METRIC_RE.search(line)
+                if m:
+                    return float(m.group('os')), float(m.group('st'))
+    return None, None
+
+
+def main():
+    cfg = load_config()
+    # Ensure ZN tuning disabled and wind off for consistent results
+    cfg['simulation_settings']['ziegler_nichols_tuning']['enable'] = False
+    cfg['scenario_settings']['enable_wind'] = False
+    cfg['controller_settings']['pid']['ki'] = 0.0
+    cfg['controller_settings']['pid']['kd'] = 0.0
+
+    limit = int(os.environ.get('LIMIT_ITERS', '30'))
+    kp_values = [round(x * 0.1, 2) for x in range(1, limit + 1)]  # 0.1 step
+    results = []
+
+    for kp in kp_values:
+        cfg['controller_settings']['pid']['kp'] = kp
+        save_config(cfg)
+
+        run_sim()
+        time.sleep(0.5)  # ensure files flushed
+        metrics_file = find_latest_metrics(kp)
+        os_val, st_val = parse_metrics(metrics_file)
+        results.append((kp, os_val, st_val))
+        print(f"Kp={kp:.2f} -> Overshoot={os_val}%, ST={st_val}s")
+
+    print("\nSummary:")
+    for kp, os_val, st_val in results:
+        print(f"{kp:.2f}, OS={os_val}%, ST={st_val}s")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- update simulation_params.yaml to use structured sections
- add `auto_pid_tuner.py` for automated PID scanning
- allow tuner loop count via `LIMIT_ITERS` env var
- run simulator from its build directory

## Testing
- `ctest --output-on-failure`
- `LIMIT_ITERS=1 python3 scripts/auto_pid_tuner.py`

------
https://chatgpt.com/codex/tasks/task_e_6843023c824083238fe3839ccdb99321