### PR TITLE
Print metrics during ZN tuning

### DIFF
--- a/agent_control_pkg/src/multi_drone_pid_test_main.cpp
+++ b/agent_control_pkg/src/multi_drone_pid_test_main.cpp
@@ -728,7 +728,8 @@ int main() {
     if (ZN_TUNING_ACTIVE) {
         std::cout << "Z-N Tuning Run (Kp_test = " << ZN_KP_TEST_VALUE << ") complete." << std::endl;
         std::cout << "Analyze CSV (" << csv_filepath.string() << ") for Drone 0 X-axis oscillations." << std::endl;
-    } else if (num_metric_phases > 0) {
+    }
+    if (num_metric_phases > 0) {
         for (int p_idx = 0; p_idx < num_metric_phases; ++p_idx) {
             if (!phase_has_been_active[p_idx]) continue;
             if(metrics_file_stream.is_open()) metrics_file_stream << "\n-- METRICS FOR PHASE " << p_idx + 1 << " --\n";


### PR DESCRIPTION
## Summary
- show final metrics even when Z-N tuning mode is active

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68444a73dc3c8323b4db5571c8c787e6